### PR TITLE
fix: handle attempts to merge function into block coverage

### DIFF
--- a/test-data/bugs/issue-2-block-coverage.json
+++ b/test-data/bugs/issue-2-block-coverage.json
@@ -1,0 +1,196 @@
+{
+  "result": [
+    {
+      "scriptId": "48",
+      "url": "fs.js",
+      "functions": [
+        {
+          "functionName": "realpathSync",
+          "ranges": [
+            {
+              "startOffset": 39013,
+              "endOffset": 42951,
+              "count": 20
+            },
+            {
+              "startOffset": 39069,
+              "endOffset": 39088,
+              "count": 15
+            },
+            {
+              "startOffset": 39088,
+              "endOffset": 39140,
+              "count": 5
+            },
+            {
+              "startOffset": 39196,
+              "endOffset": 39214,
+              "count": 0
+            },
+            {
+              "startOffset": 39341,
+              "endOffset": 39356,
+              "count": 5
+            },
+            {
+              "startOffset": 39383,
+              "endOffset": 39418,
+              "count": 1
+            },
+            {
+              "startOffset": 39418,
+              "endOffset": 39991,
+              "count": 19
+            },
+            {
+              "startOffset": 39991,
+              "endOffset": 40010,
+              "count": 0
+            },
+            {
+              "startOffset": 40012,
+              "endOffset": 40187,
+              "count": 0
+            },
+            {
+              "startOffset": 40187,
+              "endOffset": 40324,
+              "count": 19
+            },
+            {
+              "startOffset": 40324,
+              "endOffset": 42868,
+              "count": 427
+            },
+            {
+              "startOffset": 40436,
+              "endOffset": 40551,
+              "count": 34
+            },
+            {
+              "startOffset": 40551,
+              "endOffset": 40677,
+              "count": 393
+            },
+            {
+              "startOffset": 40760,
+              "endOffset": 40798,
+              "count": 187
+            },
+            {
+              "startOffset": 40770,
+              "endOffset": 40797,
+              "count": 28
+            },
+            {
+              "startOffset": 40800,
+              "endOffset": 40937,
+              "count": 257
+            },
+            {
+              "startOffset": 40891,
+              "endOffset": 40915,
+              "count": 0
+            },
+            {
+              "startOffset": 40937,
+              "endOffset": 40999,
+              "count": 170
+            },
+            {
+              "startOffset": 40999,
+              "endOffset": 41017,
+              "count": 11
+            },
+            {
+              "startOffset": 41048,
+              "endOffset": 41097,
+              "count": 0
+            },
+            {
+              "startOffset": 41097,
+              "endOffset": 42382,
+              "count": 170
+            },
+            {
+              "startOffset": 41450,
+              "endOffset": 41551,
+              "count": 135
+            },
+            {
+              "startOffset": 41503,
+              "endOffset": 41525,
+              "count": 11
+            },
+            {
+              "startOffset": 41551,
+              "endOffset": 41932,
+              "count": 35
+            },
+            {
+              "startOffset": 41875,
+              "endOffset": 41924,
+              "count": 13
+            },
+            {
+              "startOffset": 41932,
+              "endOffset": 41964,
+              "count": 35
+            },
+            {
+              "startOffset": 41964,
+              "endOffset": 42214,
+              "count": 22
+            },
+            {
+              "startOffset": 42214,
+              "endOffset": 42296,
+              "count": 34
+            },
+            {
+              "startOffset": 42296,
+              "endOffset": 42326,
+              "count": 0
+            },
+            {
+              "startOffset": 42326,
+              "endOffset": 42376,
+              "count": 34
+            },
+            {
+              "startOffset": 42382,
+              "endOffset": 42658,
+              "count": 34
+            },
+            {
+              "startOffset": 42658,
+              "endOffset": 42677,
+              "count": 0
+            },
+            {
+              "startOffset": 42679,
+              "endOffset": 42864,
+              "count": 0
+            },
+            {
+              "startOffset": 42868,
+              "endOffset": 42883,
+              "count": 18
+            },
+            {
+              "startOffset": 42883,
+              "endOffset": 42906,
+              "count": 4
+            },
+            {
+              "startOffset": 42906,
+              "endOffset": 42950,
+              "count": 18
+            }
+          ],
+          "isBlockCoverage": true
+        }
+      ]
+    }
+  ]
+}

--- a/test-data/bugs/issue-2-expected.json
+++ b/test-data/bugs/issue-2-expected.json
@@ -1,0 +1,191 @@
+{
+  "result": [
+    {
+      "scriptId": "0",
+      "url": "fs.js",
+      "functions": [
+        {
+          "functionName": "realpathSync",
+          "ranges": [
+            {
+              "startOffset": 39013,
+              "endOffset": 42951,
+              "count": 20
+            },
+            {
+              "startOffset": 39069,
+              "endOffset": 39088,
+              "count": 15
+            },
+            {
+              "startOffset": 39088,
+              "endOffset": 39140,
+              "count": 5
+            },
+            {
+              "startOffset": 39196,
+              "endOffset": 39214,
+              "count": 0
+            },
+            {
+              "startOffset": 39341,
+              "endOffset": 39356,
+              "count": 5
+            },
+            {
+              "startOffset": 39383,
+              "endOffset": 39418,
+              "count": 1
+            },
+            {
+              "startOffset": 39418,
+              "endOffset": 39991,
+              "count": 19
+            },
+            {
+              "startOffset": 39991,
+              "endOffset": 40010,
+              "count": 0
+            },
+            {
+              "startOffset": 40012,
+              "endOffset": 40187,
+              "count": 0
+            },
+            {
+              "startOffset": 40187,
+              "endOffset": 40324,
+              "count": 19
+            },
+            {
+              "startOffset": 40324,
+              "endOffset": 42868,
+              "count": 427
+            },
+            {
+              "startOffset": 40436,
+              "endOffset": 40551,
+              "count": 34
+            },
+            {
+              "startOffset": 40551,
+              "endOffset": 40677,
+              "count": 393
+            },
+            {
+              "startOffset": 40760,
+              "endOffset": 40798,
+              "count": 187
+            },
+            {
+              "startOffset": 40770,
+              "endOffset": 40797,
+              "count": 28
+            },
+            {
+              "startOffset": 40800,
+              "endOffset": 40937,
+              "count": 257
+            },
+            {
+              "startOffset": 40891,
+              "endOffset": 40915,
+              "count": 0
+            },
+            {
+              "startOffset": 40937,
+              "endOffset": 40999,
+              "count": 170
+            },
+            {
+              "startOffset": 40999,
+              "endOffset": 41017,
+              "count": 11
+            },
+            {
+              "startOffset": 41048,
+              "endOffset": 41097,
+              "count": 0
+            },
+            {
+              "startOffset": 41097,
+              "endOffset": 42382,
+              "count": 170
+            },
+            {
+              "startOffset": 41450,
+              "endOffset": 41551,
+              "count": 135
+            },
+            {
+              "startOffset": 41503,
+              "endOffset": 41525,
+              "count": 11
+            },
+            {
+              "startOffset": 41551,
+              "endOffset": 41964,
+              "count": 35
+            },
+            {
+              "startOffset": 41875,
+              "endOffset": 41924,
+              "count": 13
+            },
+            {
+              "startOffset": 41964,
+              "endOffset": 42214,
+              "count": 22
+            },
+            {
+              "startOffset": 42214,
+              "endOffset": 42296,
+              "count": 34
+            },
+            {
+              "startOffset": 42296,
+              "endOffset": 42326,
+              "count": 0
+            },
+            {
+              "startOffset": 42326,
+              "endOffset": 42376,
+              "count": 34
+            },
+            {
+              "startOffset": 42382,
+              "endOffset": 42658,
+              "count": 34
+            },
+            {
+              "startOffset": 42658,
+              "endOffset": 42677,
+              "count": 0
+            },
+            {
+              "startOffset": 42679,
+              "endOffset": 42864,
+              "count": 0
+            },
+            {
+              "startOffset": 42868,
+              "endOffset": 42883,
+              "count": 18
+            },
+            {
+              "startOffset": 42883,
+              "endOffset": 42906,
+              "count": 4
+            },
+            {
+              "startOffset": 42906,
+              "endOffset": 42950,
+              "count": 18
+            }
+          ],
+          "isBlockCoverage": true
+        }
+      ]
+    }
+  ]
+}

--- a/test-data/bugs/issue-2-func-coverage.json
+++ b/test-data/bugs/issue-2-func-coverage.json
@@ -1,0 +1,21 @@
+{
+  "result": [
+    {
+      "scriptId": "48",
+      "url": "fs.js",
+      "functions": [
+        {
+          "functionName": "realpathSync",
+          "ranges": [
+            {
+              "startOffset": 39013,
+              "endOffset": 42951,
+              "count": 3
+            }
+          ],
+          "isBlockCoverage": false
+        }
+      ]
+    }
+  ]
+}

--- a/ts/src/lib/merge.ts
+++ b/ts/src/lib/merge.ts
@@ -82,9 +82,17 @@ export function mergeScriptCovs(scriptCovs: ReadonlyArray<ScriptCov>): ScriptCov
     for (const funcCov of scriptCov.functions) {
       const rootRange: string = stringifyFunctionRootRange(funcCov);
       let funcCovs: FunctionCov[] | undefined = rangeToFuncs.get(rootRange);
-      if (funcCovs === undefined) {
+
+      if (funcCovs === undefined ||
+        // if the entry in rangeToFuncs is function-level granularity and
+        // the new coverage is block-level, prefer block-level.
+        (!funcCovs[0].isBlockCoverage && funcCov.isBlockCoverage)) {
         funcCovs = [];
         rangeToFuncs.set(rootRange, funcCovs);
+      } else if (funcCovs[0].isBlockCoverage && !funcCov.isBlockCoverage) {
+        // if the entry in rangeToFuncs is block-level granularity, we should
+        // not append function level granularity.
+        continue;
       }
       funcCovs.push(funcCov);
     }

--- a/ts/src/lib/normalize.ts
+++ b/ts/src/lib/normalize.ts
@@ -1,6 +1,6 @@
 import { compareFunctionCovs, compareRangeCovs, compareScriptCovs } from "./compare";
-import { FunctionCov, ProcessCov, ScriptCov } from "./types";
 import { RangeTree } from "./range-tree";
+import { FunctionCov, ProcessCov, ScriptCov } from "./types";
 
 /**
  * Normalizes a process coverage.

--- a/ts/src/test/merge.spec.ts
+++ b/ts/src/test/merge.spec.ts
@@ -16,6 +16,15 @@ interface MergeRangeItem {
   expected: ProcessCov;
 }
 
+const FIXTURES_DIR: string = path.join(REPO_ROOT, "test-data", "bugs");
+function loadFixture(name: string) {
+  const content: string = fs.readFileSync(
+    path.resolve(FIXTURES_DIR, `${name}.json`),
+    {encoding: "UTF-8"},
+  );
+  return JSON.parse(content);
+}
+
 describe("merge", () => {
   describe("Various", () => {
     it("accepts empty arrays for `mergeProcessCovs`", () => {
@@ -81,6 +90,34 @@ describe("merge", () => {
       };
       const actual: ProcessCov = mergeProcessCovs(inputs);
       chai.assert.deepEqual(actual, expected);
+    });
+
+    describe("mergeProcessCovs", () => {
+      // see: https://github.com/demurgos/v8-coverage/issues/2
+      it("handles function coverage merged into block coverage", () => {
+        const blockCoverage: ProcessCov = loadFixture("issue-2-block-coverage");
+        const functionCoverage: ProcessCov = loadFixture("issue-2-func-coverage");
+        const inputs: ProcessCov[] = [
+          functionCoverage,
+          blockCoverage,
+        ];
+        const expected: ProcessCov = loadFixture("issue-2-expected");
+        const actual: ProcessCov = mergeProcessCovs(inputs);
+        chai.assert.deepEqual(actual, expected);
+      });
+
+      // see: https://github.com/demurgos/v8-coverage/issues/2
+      it("handles block coverage merged into function coverage", () => {
+        const blockCoverage: ProcessCov = loadFixture("issue-2-block-coverage");
+        const functionCoverage: ProcessCov = loadFixture("issue-2-func-coverage");
+        const inputs: ProcessCov[] = [
+          blockCoverage,
+          functionCoverage,
+        ];
+        const expected: ProcessCov = loadFixture("issue-2-expected");
+        const actual: ProcessCov = mergeProcessCovs(inputs);
+        chai.assert.deepEqual(actual, expected);
+      });
     });
 
     it("accepts arrays with a single item for `mergeScriptCovs`", () => {


### PR DESCRIPTION
The Node.js test suite runs into situations where attempts are made to merge function granularity coverage into block level granularity, leading to incorrect coverage reports:

<img width="770" alt="screen shot 2019-01-19 at 9 51 22 pm" src="https://user-images.githubusercontent.com/194609/51435950-181fe300-1c38-11e9-950c-9432a6ef90eb.png">

this issue can be addressed by always preferring block level coverage.

fixes: https://github.com/demurgos/v8-coverage/issues/2
