### PR TITLE
Fix crash resulting from improper use of stack

### DIFF
--- a/ts/src/lib/range-tree.mts
+++ b/ts/src/lib/range-tree.mts
@@ -34,7 +34,7 @@ export class RangeTree {
       }
       let parent: RangeTree;
       let parentCount: number;
-      while (true) {
+      while (stack.length) {
         [parent, parentCount] = stack[stack.length - 1];
         // assert: `top !== undefined` (the ranges are sorted)
         if (range.startOffset < parent.end) {


### PR DESCRIPTION
Encountered a case where this package errors out due to an attempt to read the stack without checking if it is empty

The error originates here:
```javascript
            while (true) {
                [parent, parentCount] = stack[stack.length - 1];
[...]
```

In the edge-case I encountered, that line resulted in the error below. replacing `while(true)` with `while(stack.length)` prevents a crash. 

Full error:
```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
 ❯ RangeTree.fromSortedRanges node_modules/@bcoe/v8-coverage/dist/lib/range-tree.js:27:39
 ❯ normalizeFunctionCov node_modules/@bcoe/v8-coverage/dist/lib/normalize.js:74:41
 ❯ Object.deepNormalizeScriptCov node_modules/@bcoe/v8-coverage/dist/lib/normalize.js:59:9
 ❯ mergeScriptCovs node_modules/@bcoe/v8-coverage/dist/lib/merge.js:59:21
 ❯ mergeProcessCovs node_modules/@bcoe/v8-coverage/dist/lib/merge.js:34:21
 ❯ V8CoverageProvider.reportCoverage node_modules/@vitest/coverage-v8/dist/provider.js:217:20
 ❯ Vitest.reportCoverage node_modules/vitest/dist/vendor-node.5ce5f335.js:11384:35
 ❯ Vitest.start node_modules/vitest/dist/vendor-node.5ce5f335.js:11090:16
 ❯ startVitest node_modules/vitest/dist/vendor-node.5ce5f335.js:18061:5
 ❯ start node_modules/vitest/dist/cli.js:135:17
```